### PR TITLE
avoids non-writeable-dev-log bug.

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -1,5 +1,5 @@
 --extra-index-url https://staticfiles.krxd.net/foss/pypi/
-krux-stdlib==1.3.0
+krux-stdlib==1.3.2
 sh==1.11
 virtualenv-tools==1.0
 pip==1.4.1


### PR DESCRIPTION
Needed to build on hosted CI solutions, where /dev/log is generally not writeable.