### PR TITLE
cross build fixes

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -40,3 +40,4 @@ sphinx-rtd-theme==0.1.9
 # between 2.0.x and 3.2.x
 statsd==2.0.3
 tornado==4.3
+virtualenv==15.1.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION      = '0.0.11'
+VERSION      = '0.0.12'
 NAME         = 've-packager'
 
 # URL to the repository on Github.

--- a/vep/__init__.py
+++ b/vep/__init__.py
@@ -159,7 +159,7 @@ class Application(krux.cli.Application):
         mkdir = sh.Command('mkdir')
         mkdir('-p', "%s/bin" % self.build_dir)
         rcp = RawConfigParser()
-        # someone could be foolish enough to use a hypen in ther package name, needs to be a _.
+        # someone could be foolish enough to use a hypen in their package name, needs to be a _.
         egg = "%s.egg-info" % re.sub('-', '_', self.args.package_name)
         entry_points = os.path.join(egg, 'entry_points.txt')
         if not os.path.exists(egg) or not os.path.exists(entry_points):
@@ -219,7 +219,9 @@ class Application(krux.cli.Application):
         print("deleting previous virtual environment")
         rm('-f', '-r', self.target)
         print("creating new virtual environment")
-        virtualenv = sh.Command('virtualenv')
+        # we've got to use the virtualenv that is in ve-packager, not the system virtualenv,
+        # which might use a different version of python.
+        virtualenv = sh.Command('%s/virtualenv' % os.path.dirname(sys.executable))
         virtualenv('--no-site-packages', '-p', self.python, self.target, _out=print_line)
         # the sh module does not provide a way to create a shell with a virtualenv
         # activated, the next best thing is to set up a shortcut for pip and python


### PR DESCRIPTION
Fixes a bug where, if you try to build a project with Python 2.7, when the system Python is 2.6, setuptools fails to load, and the package never gets built.

This change bundles `virtualenv`, and uses the bundled version to create a virtualenv for the project being packaged.

For testing, I built python-krux-manage-instance:
* on Lucid, with the system Python 2.6 and 2.7, and a locally-built python 2.7.
* on Trusty, with the system Python 2.7, and a locally-built Python 2.7. 