### PR TITLE
add pip cache and dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION      = '0.0.12'
+VERSION      = '0.0.13'
 NAME         = 've-packager'
 
 # URL to the repository on Github.


### PR DESCRIPTION
Adds options to specify dependencies (via a CLI option) and a pip cache directory (via an environment variable, or a CLI option).

Testing: verified that output packages reflect the specified dependencies, and that pip wheels are not re-downloaded when the cache directory is specified, for versions of pip >= 7.1.2.