### PR TITLE
Accept requirements.txt as well as requirements.pip

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,39 @@
+## What does this PR do?
+
+_(required) Describe the effects of your pull request in detail. If multiple
+changes are involved, a bulleted list is often useful._
+
+## Why is this change being made?
+
+_(required) Describe the reasoning and background context for your
+change. Include a link to relevant ticket(s)._
+
+## How does this PR do it?
+
+_(encourged) Describe how your pull request does what it does so that your
+reviewer can better understand the changes being made. If multiple
+changes are involved, a bulleted list is often useful. Puppet run output can
+also be put here to describe the how._
+
+## How was this tested? How can the reviewer verify your testing?
+
+_(required) Describe the steps you used to test your change. Provide evidence of
+testing or explicit, repeatable instructions the reviewer can follow
+to verify your testing._
+
+## What gif best describes this PR or how it makes you feel?
+
+_(encouraged) Insert an appropriate gif/meme to brighten up your reviewer's day._
+
+## Completion checklist
+
+- [ ] The pull request has been appropriately labeled according to
+  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review).
+- [ ] The version of the package has been updated according to [Semantic Versioning](http://semver.org/).
+- [ ] The change has unit & integration tests as appropriate.
+- [ ] Documentation is up to date and correct.
+- [ ] Dependencies are correctly listed under `requirements.pip` and
+      are up to date without going over a major version.
+- [ ] Stakeholders have been notified. Workflow-impacting changes have
+      been appropriately socialized to avoid surprises.
+- [ ] The change is either small or have been canaried in the appropriate environment(s).

--- a/tests/cli_option_tests.py
+++ b/tests/cli_option_tests.py
@@ -8,6 +8,7 @@
 #
 
 from __future__ import absolute_import
+import os
 import unittest
 
 #
@@ -20,6 +21,13 @@ from mock import patch
 # Internal libraries
 #
 import vep
+
+
+def my_isfile(filename):
+    """
+    Test function which calls os.path.isfile
+    """
+    return os.path.isfile(filename)
 
 
 class CliOptionTests(unittest.TestCase):
@@ -48,3 +56,30 @@ class CliOptionTests(unittest.TestCase):
         self.assertEqual(self.TEST_VERSION, app.get_setup_option('version'))
         self.assertEqual(self.TEST_NAME, app.get_setup_option('name'))
         self.assertEqual(self.TEST_URL, app.get_setup_option('url'))
+
+    @patch('os.path.isfile', side_effect=lambda f: f == './requirements.txt')
+    def test_requirements_txt_file(self, _):
+        """
+        Test that, if a requirements.txt file exists, it will be chosen.
+        """
+        app = vep.Application('APP-NAME')
+        self.assertEqual(app.args.pip_requirements, None)
+        self.assertEqual(app._pip_requirements_filename(), './requirements.txt')
+
+    @patch('os.path.isfile', side_effect=lambda f: f == './requirements.pip')
+    def test_requirements_pip_file(self, _):
+        """
+        Test that, if a requirements.pip file exists, it will be chosen.
+        """
+        app = vep.Application('APP-NAME')
+        self.assertEqual(app.args.pip_requirements, None)
+        self.assertEqual(app._pip_requirements_filename(), './requirements.pip')
+
+    @patch('sys.argv', ['ve-packager', '--pip-requirements', 'my-requirements.txt'])
+    @patch('os.path.isfile', side_effect=lambda f: f == 'my-requirements.txt')
+    def test_requirements_my_file(self, _):
+        """
+        Test that supplied requirements file is honored.
+        """
+        app = vep.Application('APP-NAME')
+        self.assertEqual(app.args.pip_requirements, 'my-requirements.txt')

--- a/tests/cli_option_tests.py
+++ b/tests/cli_option_tests.py
@@ -48,4 +48,3 @@ class CliOptionTests(unittest.TestCase):
         self.assertEqual(self.TEST_VERSION, app.get_setup_option('version'))
         self.assertEqual(self.TEST_NAME, app.get_setup_option('name'))
         self.assertEqual(self.TEST_URL, app.get_setup_option('url'))
-

--- a/vep/__init__.py
+++ b/vep/__init__.py
@@ -306,7 +306,7 @@ class Application(krux.cli.Application):
 
         if not found:
             raise VEPackagerError(
-                'could not find any of these pip requirements files: %s'.format(
+                'could not find any of these pip requirements files: {}'.format(
                     ', '.join(filenames)))
         return path_filename
 

--- a/vep/__init__.py
+++ b/vep/__init__.py
@@ -291,10 +291,10 @@ class Application(krux.cli.Application):
         :return: Filename of pip requirements
         :rtype: str
         """
-        filenames = []
         if self.args.pip_requirements:
-            filenames.append(self.args.pip_requirements)
-        filenames.extend(DEFAULT_REQUIREMENTS_FILES)
+            filenames = list(self.args.pip_requirements)
+        else:
+            filenames = list(DEFAULT_REQUIREMENTS_FILES)
 
         path_filename = None
         found = False

--- a/vep/__init__.py
+++ b/vep/__init__.py
@@ -281,7 +281,7 @@ class Application(krux.cli.Application):
             else:
                 pip('install', "%s==%s" % (tool, version), _out=print_line)
 
-    def _pip_requirements_filename(self, path=''):
+    def _pip_requirements_filename(self, path='.'):
         """
         Returns filename of pip requirements file, & verifies that the file exists.
 
@@ -299,7 +299,7 @@ class Application(krux.cli.Application):
         path_filename = None
         found = False
         for filename in filenames:
-            path_filename = filename if not path else os.path.join(path, filename)
+            path_filename = os.path.join(path, filename)
             if os.path.isfile(path_filename):
                 found = True
                 break


### PR DESCRIPTION
## What does this PR do?
By default, accept `requirements.txt` as well as `requirements.pip` as the package requirements file.

## Why is this change being made?
We’ve started using `requirements.txt` instead of `requirements.pip`, so we need to accept both cases.

## How does this PR do it?
See method `vep._pip_requirements_filename.Application._pip_requirements_filename()`.

## How was this tested? How can the reviewer verify your testing?
Added some new tests and ran `nosetests`.

## What gif best describes this PR or how it makes you feel?
![4e5e2a518f8a9bd391dbe1a7d9da5b5f](https://user-images.githubusercontent.com/496931/53524795-3e396e00-3a95-11e9-82c4-f573c1656af0.jpg)

## Completion checklist
- [x] The pull request has been appropriately labeled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review).
- [x] The version of the package has been updated according to [Semantic Versioning](http://semver.org/).
- [x] The change has unit & integration tests as appropriate.
- [x] Documentation is up to date and correct.
- [x] Dependencies are correctly listed under `requirements.pip` and
      are up to date without going over a major version.
- [x] Stakeholders have been notified. Workflow-impacting changes have
      been appropriately socialized to avoid surprises.
- [x] The change is either small or have been canaried in the appropriate environment(s).