### PR TITLE
Jo w 6562226 py3 bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 sh==1.12.14
 # note that this virtualenv-tools is our fork, not the public one, the source is
 # here: https://github.com/krux/virtualenv-tools
-virtualenv-tools==1.0.1
+virtualenv-tools3==2.0.2
 
 # Krux libraries
 kruxstatsd==0.3.6

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     install_requires = [
         "krux-stdlib",
         "sh",
-        "virtualenv-tools"
+        "virtualenv-tools3"
     ],
     entry_points     = {
         'console_scripts': [

--- a/vep/__init__.py
+++ b/vep/__init__.py
@@ -14,7 +14,7 @@ else:
     PYVER = '/usr/bin/python3'
 
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 
 DEFAULT_PACKAGE_FORMAT = 'deb'


### PR DESCRIPTION
## What does this PR do?

Moves to virtualenv-tools3

## Why is this change being made?

virtualenv-tools is required by the ve-packager but it's an abandoned project. Yelp picked it up, renamed it, and has maintained it including adding python3 support.

## How does this PR do it?

Bumps the name and version in requirements.txt and setup.py

## How was this tested? How can the reviewer verify your testing?

Slow and methodical process in local containers against python2 and python3.

## What gif best describes this PR or how it makes you feel?

![alt text](https://media.giphy.com/media/453QsWPQj5bsQaqp8M/giphy.gif)

## Completion checklist

- [ ] The pull request has been appropriately labeled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review).
- [ ] The version of the package has been updated according to [Semantic Versioning](http://semver.org/).
- [ ] The change has unit & integration tests as appropriate.
- [ ] Documentation is up to date and correct.
- [ ] Dependencies are correctly listed under `requirements.pip` and
      are up to date without going over a major version.
- [ ] Stakeholders have been notified. Workflow-impacting changes have
      been appropriately socialized to avoid surprises.
- [ ] The change is either small or have been canaried in the appropriate environment(s).
