### PR TITLE
Remove a no longer supported option

### DIFF
--- a/vep/__init__.py
+++ b/vep/__init__.py
@@ -14,7 +14,7 @@ else:
     PYVER = '/usr/bin/python3'
 
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 
 DEFAULT_PACKAGE_FORMAT = 'deb'
@@ -354,7 +354,7 @@ class Application(krux.cli.Application):
         if os.path.exists('%s/virtualenv' % os.path.dirname(self.python)):
             virtualenv = sh.Command('%s/virtualenv' % os.path.dirname(self.python))
 
-        virtualenv('--no-site-packages', '-p', self.python, self.target, _out=print_line)
+        virtualenv('-p', self.python, self.target, _out=print_line)
         # the sh module does not provide a way to create a shell with a virtualenv
         # activated, the next best thing is to set up a shortcut for pip and python
         # in the target virtualenv


### PR DESCRIPTION
## What does this PR do?

Removes a no longer supported Virtualenv option

`root@a7f1a6c0f46e:/work# virtualenv --help
Usage: virtualenv [OPTIONS] DEST_DIR

Options:
  --version             show program's version number and exit
  -h, --help            show this help message and exit
  -v, --verbose         Increase verbosity.
  -q, --quiet           Decrease verbosity.
  -p PYTHON_EXE, --python=PYTHON_EXE
                        The Python interpreter to use, e.g.,
                        --python=python3.5 will use the python3.5 interpreter
                        to create the new environment.  The default is the
                        interpreter that virtualenv was installed with
                        (/usr/bin/python3)
  --clear               Clear out the non-root install and start from scratch.
  --no-site-packages    DEPRECATED. Retained only for backward compatibility.
                        Not having access to global site-packages is now the
                        default behavior.
`
As of Virtualenv 20 --no-site-pacakges is no longer an option, this behavior is default.

## Why is this change being made?

ve-package is exploding on [CB](https://cb.krxd.net/cje/job/docker-compose-process-deb/DISTRO=bionic,PYVER=python3/9/console)

## How does this PR do it?

removes the now invalid option

## How was this tested? How can the reviewer verify your testing?

Locally

## What gif best describes this PR or how it makes you feel?

![alt text](https://media.giphy.com/media/3o7TKsSwntcdn7i8j6/giphy.gif)

## Completion checklist

- [ ] The pull request has been appropriately labeled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review).
- [ ] The version of the package has been updated according to [Semantic Versioning](http://semver.org/).
- [ ] The change has unit & integration tests as appropriate.
- [ ] Documentation is up to date and correct.
- [ ] Dependencies are correctly listed under `requirements.pip` and
      are up to date without going over a major version.
- [ ] Stakeholders have been notified. Workflow-impacting changes have
      been appropriately socialized to avoid surprises.
- [ ] The change is either small or have been canaried in the appropriate environment(s).
