### PR TITLE
W-8909569 resolve catch22 defining __version__

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,7 @@ Package setup for python-virtualenv-packager, aka ve-packager.
 from __future__ import absolute_import
 from setuptools import setup, find_packages
 
-# version: this requires an environment with dependencies installed.
-from vep import __version__
+__version__ = '0.1.4'
 
 # We use the version to construct the DOWNLOAD_URL.
 NAME         = 've-packager'
@@ -24,7 +23,7 @@ REPO_URL     = 'https://github.com/krux/python-virtualenv-packager'
 DOWNLOAD_URL = ''.join((REPO_URL, '/tarball/release/', __version__))
 
 # Requirements
-# If you have the option, run "pip install -r requirements.pip"
+# If you have the option, run "pipenv install"
 
 setup(
     name             = NAME,

--- a/vep/__init__.py
+++ b/vep/__init__.py
@@ -13,10 +13,6 @@ else:
     from configparser import RawConfigParser
     PYVER = '/usr/bin/python3'
 
-
-__version__ = '0.1.3'
-
-
 DEFAULT_PACKAGE_FORMAT = 'deb'
 # Before 2019, we standardized on requirements.pip; after that we switched to requirements.txt.
 DEFAULT_REQUIREMENTS_FILES = ('requirements.txt', 'requirements.pip')


### PR DESCRIPTION
## What does this PR do?

_Fix this catch-22 in CI, which tries to invoke setup.py in order to determine dependencies before installing dependencies:_

```
16:19:03 ==> docker:   File "setup.py", line 15, in <module>
16:19:03 ==> docker:     from vep import __version__
16:19:03 ==> docker:   File "/tmp/python-virtualenv-packager/vep/__init__.py", line 1, in <module>
16:19:03 ==> docker:     import krux.cli
```

## How does it do it?

_Move the definition of `__version__` into setup.py; it's not used anywhere else._

## How is it tested?

_See CI test below, and manual check:_
```
$ pipenv run python3 -m vep.__init__ -h
usage: __init__.py [-h] [--log-level {critical,error,warning,info,debug}] [--log-file LOG_FILE] [--no-syslog-facility]
                   [--syslog-facility SYSLOG_FACILITY] [--no-log-to-stdout] [--stats] [--stats-host STATS_HOST] [--stats-port STATS_PORT]
                   [--stats-environment STATS_ENVIRONMENT] [--package-prefix PACKAGE_PREFIX] [--repo-url REPO_URL]
                   [--package-format PACKAGE_FORMAT] [--package-name PACKAGE_NAME] [--package-version PACKAGE_VERSION] [--python PYTHON]
                   [--skip-scripts] [--shim-script SHIM_SCRIPT] [--build-number BUILD_NUMBER] [--pip-requirements PIP_REQUIREMENTS]
                   [--pip-version PIP_VERSION] [--setuptools-version SETUPTOOLS_VERSION] [--directory DIRECTORY] [--dependency DEPENDENCY]
                   [--extra-path EXTRA_PATH] [--pip-cache PIP_CACHE]

ve-packager

optional arguments:
  -h, --help            show this help message and exit

logging:
  --log-level {critical,error,warning,info,debug}
                        Verbosity of logging. (env: LOG_LEVEL) (default: warning)
  --log-file LOG_FILE   Full-qualified path to the log file (env: LOG_FILE) (default: None)
  --no-syslog-facility  disable syslog facility
  --syslog-facility SYSLOG_FACILITY
                        syslog facility to use (env: SYSLOG_FACILITY) (default: local7)
  --no-log-to-stdout    Suppress logging to stdout/stderr (default: True)

stats:
  --stats               Enable sending statistics to statsd. (env: STATS) (default: False)
  --stats-host STATS_HOST
                        Statsd host to send statistics to. (env: STATS_HOST) (default: localhost)
  --stats-port STATS_PORT
                        Statsd port to send statistics to. (env: STATS_PORT) (default: 8125)
  --stats-environment STATS_ENVIRONMENT
                        Statsd environment. (env: STATS_ENVIRONMENT) (default: dev)

ve-packager:
  --package-prefix PACKAGE_PREFIX
                        Path to prefix the entire package with (default: /usr/local)
  --repo-url REPO_URL   Repo URL to pass through to fpm (default: None)
  --package-format PACKAGE_FORMAT
                        The package format, if not deb (default: deb)
  --package-name PACKAGE_NAME
                        The package name, as seen in apt (default: None)
  --package-version PACKAGE_VERSION
                        The package version. (default: None)
  --python PYTHON       The path to python to use. Must be a real file, not a symlink. (default: /usr/bin/python3)
  --skip-scripts        Skip installing all the scripts in all the setup.py files in all the requirements (default: False)
  --shim-script SHIM_SCRIPT
                        An extra script to run between the build and package steps. If you need to do unnatural things to make your package work,
                        this is the place to do them. The script will be called via the sh module and therefore needs a shebang line. (default:
                        None)
  --build-number BUILD_NUMBER
                        A build number, ie from your CI, if you want it to be appended the version number. (default: False)
  --pip-requirements PIP_REQUIREMENTS
                        (default: None)
  --pip-version PIP_VERSION
                        Version of pip to install in the virtualenv where your application is built. (default: latest)
  --setuptools-version SETUPTOOLS_VERSION
                        Version of setuptools to install in the virtualenv where your application is built. (default: latest)
  --directory DIRECTORY
                        Path to look in for the code you want to virtualenv-packageify. default to current directory. (default:
                        /Users/rich.braun/krux/python-virtualenv-packager)
  --dependency DEPENDENCY
                        a package on which your package should depend. Passed through to fpm as -d. Pass multiple times for additional
                        dependencies. (default: [])
  --extra-path EXTRA_PATH
                        Additional paths *in your project* that you want added in to the package. (default: [])
  --pip-cache PIP_CACHE
                        directory to use as the pip cache; passed to pip as --cache-dir, which may not be available on older versions of pip.
                        (default: None)
```

The new coverage report (at end of cloudbees console output) looks like:
```
12:25:16 Name              Stmts   Miss Branch BrPart  Cover   Missing
12:25:16 -------------------------------------------------------------
12:25:16 vep/__init__.py     205     86     58     14    52%   9->10, 10-11, 79->80, 80, 90->96, 91->94, 94, 204-215, 218-221, 224-247, 250-274, 283->286, 286, 298->299, 299, 305->311, 311->312, 312, 324->325, 325, 333->334, 334-335, 337->342, 339->337, 342, 354->355, 355, 372-404, 408-409, 412->413, 413
12:25:16 -------------------------------------------------------------
12:25:16 TOTAL               205     86     58     14    52%
12:25:16 ----------------------------------------------------------------------
12:25:16 Ran 4 tests in 47.287s
```
## What gif best describes this PR or how it makes you feel?

![catch-22](https://media.giphy.com/media/o0DHXWmaZVvB8IY6VU/giphy.gif)

## Completion checklist

- [x] The pull request has been appropriately labeled according to our
      [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review)
- [x] Stakeholders have been notified. Workflow-impacting changes have
      been appropriately socialized to avoid surprises.
- [x] The associated SOPKB entry has been updated along with relevant diagrams.
- [x] Linked this PR to the appropriate GUS ticket.
